### PR TITLE
Proof of Concept: Remove saved filters from the User entity.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -187,6 +187,14 @@ public class SubmissionListController {
             return new ApiResponse(SUCCESS);
         }
 
+        // TODO: Something should be done for when other users are using the public filter being deleted.
+        // Filter is being deleted by the current user, so remove it from the active filter before deleting.
+        if (user.getActiveFilter() != null && user.getActiveFilter().getId() == id) {
+            user.setActiveFilter(null);
+
+            user = userRepo.save(user);
+        }
+
         namedSearchFilterGroupRepo.deleteById(id);
 
         if (namedSearchFilterGroupRepo.findById(id) == null) {

--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -197,11 +197,7 @@ public class SubmissionListController {
 
         namedSearchFilterGroupRepo.deleteById(id);
 
-        if (namedSearchFilterGroupRepo.findById(id) == null) {
-            return new ApiResponse(SUCCESS);
-        }
-
-        return new ApiResponse(ERROR, "Failed to delete filter with ID " + id + ".");
+        return new ApiResponse(SUCCESS);
     }
 
     @PreAuthorize("hasRole('REVIEWER')")

--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -290,7 +290,7 @@ public class SubmissionListController {
     @RequestMapping("/all-saved-filter-criteria")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse getAllSaveFilterCriteria(@WeaverUser User user) {
-        return new ApiResponse(SUCCESS, namedSearchFilterGroupRepo.findByUserAndSavedFlagTrueOrPublicFlagTrue(user));
+        return new ApiResponse(SUCCESS, namedSearchFilterGroupRepo.findByUserAndSavedFlagTrueOrPublicFlagTrueAndSavedFlagTrue(user));
     }
 
     @PostMapping(value = "/save-filter-criteria")

--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -296,6 +296,7 @@ public class SubmissionListController {
     @PostMapping(value = "/save-filter-criteria")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse saveFilterCriteria(@WeaverUser User user, @WeaverValidatedModel NamedSearchFilterGroup namedSearchFilterGroup) {
+        namedSearchFilterGroup.setId(null);
         namedSearchFilterGroup.setSavedFlag(true);
         namedSearchFilterGroup.setUser(user);
 

--- a/src/main/java/org/tdl/vireo/model/NamedSearchFilterGroup.java
+++ b/src/main/java/org/tdl/vireo/model/NamedSearchFilterGroup.java
@@ -54,6 +54,9 @@ public class NamedSearchFilterGroup extends ValidatingBaseEntity {
     private Boolean columnsFlag;
 
     @Column(nullable = false)
+    private Boolean savedFlag;
+
+    @Column(nullable = false)
     private Boolean umiRelease;
 
     @Column(nullable = true)
@@ -74,6 +77,7 @@ public class NamedSearchFilterGroup extends ValidatingBaseEntity {
     public NamedSearchFilterGroup() {
         setPublicFlag(false);
         setColumnsFlag(false);
+        setSavedFlag(false);
         setUmiRelease(false);
         setSavedColumns(new ArrayList<SubmissionListColumn>());
         setNamedSearchFilters(new HashSet<NamedSearchFilter>());
@@ -131,6 +135,24 @@ public class NamedSearchFilterGroup extends ValidatingBaseEntity {
 
     public void setColumnsFlag(Boolean columnsFlag) {
         this.columnsFlag = columnsFlag;
+    }
+
+    /**
+     * Get the saved flag.
+     *
+     * @return The value assigned.
+     */
+    public Boolean getSavedFlag() {
+        return savedFlag;
+    }
+
+    /**
+     * Set the saved flag.
+     *
+     * @param savedFlag The value to assign.
+     */
+    public void setSavedFlag(Boolean savedFlag) {
+        this.savedFlag = savedFlag;
     }
 
     /**

--- a/src/main/java/org/tdl/vireo/model/User.java
+++ b/src/main/java/org/tdl/vireo/model/User.java
@@ -7,6 +7,13 @@ import static javax.persistence.CascadeType.REMOVE;
 import static javax.persistence.FetchType.EAGER;
 import static javax.persistence.FetchType.LAZY;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import edu.tamu.weaver.auth.model.AbstractWeaverUserDetails;
+import edu.tamu.weaver.user.model.IRole;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -14,7 +21,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -24,26 +30,13 @@ import javax.persistence.Enumerated;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
-
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Formula;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.tdl.vireo.model.response.Views;
 import org.tdl.vireo.model.validation.UserValidator;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-import edu.tamu.weaver.auth.model.AbstractWeaverUserDetails;
-import edu.tamu.weaver.user.model.IRole;
 
 @Entity
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
@@ -125,17 +118,12 @@ public class User extends AbstractWeaverUserDetails {
     @ManyToOne(cascade = { REFRESH, MERGE }, fetch = LAZY, optional = true)
     private NamedSearchFilterGroup activeFilter;
 
-    @Fetch(FetchMode.SELECT)
-    @OneToMany(cascade = { REFRESH }, fetch = EAGER)
-    private List<NamedSearchFilterGroup> savedFilters;
-
     public User() {
         setModelValidator(new UserValidator());
         setSettings(new TreeMap<String, String>());
         setShibbolethAffiliations(new TreeSet<String>());
         setSubmissionViewColumns(new ArrayList<SubmissionListColumn>());
         setFilterColumns(new ArrayList<SubmissionListColumn>());
-        setSavedFilters(new ArrayList<NamedSearchFilterGroup>());
         setPageSize(10);
     }
 
@@ -454,40 +442,6 @@ public class User extends AbstractWeaverUserDetails {
      */
     public void setActiveFilter(NamedSearchFilterGroup activeFilter) {
         this.activeFilter = activeFilter;
-    }
-
-    /**
-     * @return the savedFilters
-     */
-    public List<NamedSearchFilterGroup> getSavedFilters() {
-        return savedFilters;
-    }
-
-    /**
-     * @param savedFilters the savedFilters to set
-     */
-    public void setSavedFilters(List<NamedSearchFilterGroup> savedFilters) {
-        this.savedFilters = savedFilters;
-    }
-
-    /**
-     * Add a saved filter.
-     *
-     * @param savedFilter The saved filter to add.
-     */
-    public void addSavedFilter(NamedSearchFilterGroup savedFilter) {
-        if (!this.savedFilters.contains(savedFilter)) {
-            this.savedFilters.add(savedFilter);
-        }
-    }
-
-    /**
-     * Remove a saved filter.
-     *
-     * @param savedFilter The saved filter to remove.
-     */
-    public void removeSavedFilter(NamedSearchFilterGroup savedFilter) {
-        this.savedFilters.remove(savedFilter);
     }
 
     /**

--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -12,6 +12,8 @@ public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilter
 
     public List<NamedSearchFilterGroup> findByUserAndSavedFlagTrueOrPublicFlagTrueAndSavedFlagTrue(User user);
 
+    public List<NamedSearchFilterGroup> findByUserAndSavedFlagFalse(User user);
+
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -10,7 +10,7 @@ import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilterGroup>, NamedSearchFilterGroupRepoCustom {
 
-    public List<NamedSearchFilterGroup> findByUserIsNotAndPublicFlagTrue(User user);
+    public List<NamedSearchFilterGroup> findByUserAndSavedFlagTrueOrPublicFlagTrue(User user);
 
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 

--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -10,7 +10,7 @@ import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilterGroup>, NamedSearchFilterGroupRepoCustom {
 
-    public List<NamedSearchFilterGroup> findByUserAndSavedFlagTrueOrPublicFlagTrue(User user);
+    public List<NamedSearchFilterGroup> findByUserAndSavedFlagTrueOrPublicFlagTrueAndSavedFlagTrue(User user);
 
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 

--- a/src/main/java/org/tdl/vireo/model/repo/impl/NamedSearchFilterGroupRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/NamedSearchFilterGroupRepoImpl.java
@@ -38,6 +38,7 @@ public class NamedSearchFilterGroupRepoImpl extends AbstractWeaverRepoImpl<Named
         newNamedSearchFilterGroup.setPublicFlag(namedSearchFilterGroup.getPublicFlag());
         newNamedSearchFilterGroup.setUmiRelease(namedSearchFilterGroup.getUmiRelease());
         newNamedSearchFilterGroup.setColumnsFlag(namedSearchFilterGroup.getColumnsFlag());
+        newNamedSearchFilterGroup.setSavedFlag(namedSearchFilterGroup.getSavedFlag());
         namedSearchFilterGroup.getNamedSearchFilters().forEach(namedSearchFilter -> {
             newNamedSearchFilterGroup.addFilterCriterion(namedSearchFilterRepo.clone(namedSearchFilter));
         });

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -1085,12 +1085,14 @@ var apiMapping = {
         create: {
             'endpoint': '/private/queue',
             'controller': 'submission-list',
-            'method': 'save-filter-criteria'
+            'method': 'save-filter-criteria',
+            'httpMethod': 'POST'
         },
         remove: {
             'endpoint': '/private/queue',
             'controller': 'submission-list',
-            'method': 'remove-saved-filter'
+            'method': 'remove-saved-filter',
+            'httpMethod': 'DELETE'
         }
     }
 };

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -772,9 +772,19 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
         $scope.removeSaveFilter = function (filter) {
             $scope.resetPagination();
 
-            SavedFilterRepo.delete(filter).then(function () {
-                SavedFilterRepo.reset();
+            angular.extend(apiMapping.SavedFilter.remove, {
+                "method": apiMapping.SavedFilter.remove.method + "/" + filter.id
             });
+
+            var promise = WsApi.fetch(apiMapping.SavedFilter.remove);
+
+            promise.then(function (res) {
+                if (res.meta && res.meta.status == "SUCCESS") {
+                    SavedFilterRepo.reset();
+                }
+            });
+
+            return promise;
         };
 
         $scope.resetRemoveFilters = function () {


### PR DESCRIPTION
Improve the saved filters design at the database level by removing the saved filter from the User entity. Add a `saved` boolean on the NamedSearchFilterGroup entity.

This proof of concept focuses only on the back end and makes the absolute minimal changes (even if not ideal) on the front end. This attempts to avoid addressing the other problems by entirely ignoring them.

The remove NamedSearchFilterGroup endpoint is now changed to a DELETE request that accepts an ID. A full entity is not needed and should not be required. This is to avoid validating an entity to be deleted. If the entity has bad data, it does not matter.
Just delete it.
The only important thing here is the ID.

Additional checks are performed such that a non-existent entity is not deleted. Generate a warning but still return SUCCESS as the desired behavior of removing a non-existent ID should equate to that ID not existing after this operation is complete.

Add an additional check after the delete to ensure that the delete is successful. If the entity by the given ID still exists after the delete, then return ERROR. (The deleteById() does not appear to return a status designating if delete failed or not.)

The `getAllSaveFilterCriteria()` is now able to be changed into a single function call. This function call just directly fetches from the NamedSearchFilterGroup table and fetches by (owned by current user AND is saved, OR has public flag set to TRUE).

The `/save-filter-criteria` end point is simplified to a single save action. There is no data on the user directly anymore, removing the necessity to maintain an additional table in the DB. The save can now be directly against the NamedSearchFilterGroup entity's table. The existing behavior of `/save-filter-criteria` is a "create new" and not an "update existing" design, whose behavior is preserved.

The NamedSearchFilterGroup entity now has a `savedFlag`. This flag designates what is called a "saved" filter. This is an alternative database design to having the NamedSearchFilterGroup on each User entity in the DB.